### PR TITLE
Update structural tests for deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 linters-settings:
   lll:
     line-length: 170
+  cyclop:
+    max-complexity: 15
 linters:
   enable-all: true
   disable:

--- a/test/acceptance/client_server_test.go
+++ b/test/acceptance/client_server_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Client server", Ordered, func() {
 })
 
 // verifyExecutable verifies that the executable file matches the target OS and architecture.
-func verifyExecutable(filePath, osName, arch string) error { //nolint:cyclop
+func verifyExecutable(filePath, osName, arch string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", filePath, err)

--- a/test/acceptance/fbc_images_test.go
+++ b/test/acceptance/fbc_images_test.go
@@ -42,6 +42,7 @@ var _ = Describe("File-based catalog images", Ordered, func() {
 			var bundles []olm.Bundle
 			var channels []olm.Channel
 			var packages []olm.Package
+			var deprecation olm.Deprecation
 
 			It("extract catalog.json", func() {
 				dir, err := os.MkdirTemp("", key)
@@ -65,6 +66,8 @@ var _ = Describe("File-based catalog images", Ordered, func() {
 						channels = append(channels, typedObj)
 					case olm.Package:
 						packages = append(packages, typedObj)
+					case olm.Deprecation:
+						deprecation = typedObj
 					}
 				}
 
@@ -88,7 +91,7 @@ var _ = Describe("File-based catalog images", Ordered, func() {
 			})
 
 			It("verify channels", func() {
-				expectedChannels := []string{"stable", "candidate-v1.1.0", "stable-v1.0"}
+				expectedChannels := []string{"stable", "stable-v1.1", "stable-v1.0"}
 				Expect(channels).To(HaveLen(len(expectedChannels)))
 
 				for _, channel := range channels {
@@ -110,6 +113,14 @@ var _ = Describe("File-based catalog images", Ordered, func() {
 				Expect(exists).To(BeTrue(), fmt.Sprintf("olm bundle with %s hash not found", bundleImageHash))
 			})
 
+			It("verify deprecations", func() {
+				expectedDeprecations := []string{"stable-v1.0", "rhtas-operator.v1.0.0", "rhtas-operator.v1.0.1", "rhtas-operator.v1.0.2"}
+				Expect(deprecation.Entries).To(HaveLen(len(expectedDeprecations)))
+
+				for _, entry := range deprecation.Entries {
+					Expect(expectedDeprecations).To(ContainElement(entry.Reference.Name))
+				}
+			})
 		},
 		ocps)
 })

--- a/test/support/olm/catalog.go
+++ b/test/support/olm/catalog.go
@@ -45,7 +45,7 @@ func ParseCatalogJSON(reader io.Reader) ([]interface{}, error) {
 				return nil, fmt.Errorf("failed to parse OLM bundle: %w", err)
 			}
 			result = append(result, bundle)
-		
+
 		case "olm.deprecations":
 			var deprecation Deprecation
 			err = json.Unmarshal(rawJSON(raw), &deprecation)

--- a/test/support/olm/catalog.go
+++ b/test/support/olm/catalog.go
@@ -45,6 +45,14 @@ func ParseCatalogJSON(reader io.Reader) ([]interface{}, error) {
 				return nil, fmt.Errorf("failed to parse OLM bundle: %w", err)
 			}
 			result = append(result, bundle)
+		
+		case "olm.deprecations":
+			var deprecation Deprecation
+			err = json.Unmarshal(rawJSON(raw), &deprecation)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse OLM deprecation: %w", err)
+			}
+			result = append(result, deprecation)
 
 		default:
 			return nil, fmt.Errorf("unknown schema: %v", raw["schema"])

--- a/test/support/olm/types.go
+++ b/test/support/olm/types.go
@@ -35,7 +35,7 @@ type Property struct {
 	Value interface{} `json:"value"`
 }
 
-// Deprecation Schema
+// Deprecation Schema.
 type Deprecation struct {
 	Schema  string             `json:"schema"`
 	Package string             `json:"package"`

--- a/test/support/olm/types.go
+++ b/test/support/olm/types.go
@@ -34,3 +34,20 @@ type Property struct {
 	Type  string      `json:"type"`
 	Value interface{} `json:"value"`
 }
+
+// Deprecation Schema
+type Deprecation struct {
+	Schema  string             `json:"schema"`
+	Package string             `json:"package"`
+	Entries []DeprecationEntry `json:"entries"`
+}
+
+type DeprecationEntry struct {
+	Message   string    `json:"message"`
+	Reference Reference `json:"reference"`
+}
+
+type Reference struct {
+	Name   string `json:"name"`
+	Schema string `json:"schema"`
+}


### PR DESCRIPTION
Small pr to update the structural tests to support deprecations, and removing the candidate-v1.1.0 from the expected channels