### PR TITLE
chore: operator images and repositories.json

### DIFF
--- a/test/support/test_constants.go
+++ b/test/support/test_constants.go
@@ -28,6 +28,7 @@ func MandatoryTasOperatorImageKeys() []string {
 		"trillian-log-server-image",
 		"trillian-log-signer-image",
 		"trillian-db-image",
+		"trillian-create-tree-image",
 
 		"fulcio-server-image",
 

--- a/testdata/repositories.json
+++ b/testdata/repositories.json
@@ -31,6 +31,21 @@
       "published": false
     },
     {
+      "repository": "rhtas/policy-controller-rhel9-operator",
+      "_id": "684c3637e9bee0b505a2c854",
+      "published": false
+    },
+    {
+      "repository": "rhtas/policy-controller-operator-bundle",
+      "_id": "684c3703b6603f6203b958f6",
+      "published": false
+    },
+    {
+      "repository": "rhtas/policy-controller-rhel9",
+      "_id": "684c47e98de4bcf89749e168",
+      "published": false
+    },
+    {
       "repository": "rhtas/rhtas-rhel9-operator",
       "_id": "65e79775f4abd6689b4f056c",
       "published": true


### PR DESCRIPTION
## Summary by Sourcery

Include the missing trillian-create-tree-image key in operator image constants and refresh the repositories.json test data.

Tests:
- Add trillian-create-tree-image to MandatoryTasOperatorImageKeys in test support

Chores:
- Update testdata repositories.json