### PR TITLE
Ansible now uses same tuf image as operator

### DIFF
--- a/test/acceptance/ansible_images_test.go
+++ b/test/acceptance/ansible_images_test.go
@@ -99,15 +99,6 @@ var _ = Describe("Trusted Artifact Signer Ansible", Ordered, func() {
 	It("all ansible TAS image hashes are also defined in releases snapshot", func() {
 		mapped := make(map[string]string)
 		for _, imageKey := range support.AnsibleTasImageKeys() {
-
-			// skip, while ansible uses older tuf image
-			if imageKey == "tas_single_node_tuf_image" {
-				log.Printf("Ansible uses differet TUF image - skipping")
-				log.Printf("  Ansible:  %s", ansibleTasImages[imageKey])
-				log.Printf("  Snapshot: %s", snapshotData.Images[support.ConvertAnsibleImageKey(imageKey)])
-				continue
-			}
-
 			aSha := support.ExtractHash(ansibleTasImages[imageKey])
 			if _, keyExist := snapshotData.Images[support.ConvertAnsibleImageKey(imageKey)]; !keyExist {
 				mapped[imageKey] = "MISSING"


### PR DESCRIPTION
## Summary by Sourcery

Remove the special-case skip for the single-node TUF image in the Ansible acceptance test so that Ansible now uses and validates the same TUF image as the operator.

Enhancements:
- Unify TUF image usage by dropping the older-image exception in Ansible.

Tests:
- Expand the Ansible acceptance test to include the single-node TUF image by removing its skip logic.