### PR TITLE
New operator image name for create tree

### DIFF
--- a/test/support/test_constants.go
+++ b/test/support/test_constants.go
@@ -28,7 +28,7 @@ func MandatoryTasOperatorImageKeys() []string {
 		"trillian-log-server-image",
 		"trillian-log-signer-image",
 		"trillian-db-image",
-		"trillian-create-tree-image",
+		"createtree-image",
 
 		"fulcio-server-image",
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Rename mandatory create-tree operator image key from 'trillian-create-tree-image' to 'createtree-image' in test constants