### PR TITLE
Add channel for 1.3

### DIFF
--- a/test/acceptance/fbc_images_test.go
+++ b/test/acceptance/fbc_images_test.go
@@ -91,7 +91,7 @@ var _ = Describe("File-based catalog images", Ordered, func() {
 			})
 
 			It("verify channels", func() {
-				expectedChannels := []string{"stable", "stable-v1.1", "stable-v1.0", "stable-v1.2"}
+				expectedChannels := []string{"stable", "stable-v1.1", "stable-v1.0", "stable-v1.2", "stable-v1.3"}
 				Expect(channels).To(HaveLen(len(expectedChannels)))
 
 				for _, channel := range channels {


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update expectedChannels in fbc_images_test.go to include the stable-v1.3 channel