### PR TITLE
Check image labels

### DIFF
--- a/test/acceptance/releases_images_test.go
+++ b/test/acceptance/releases_images_test.go
@@ -66,29 +66,24 @@ var _ = Describe("Trusted Artifact Signer Releases", Ordered, func() {
 			imageDataList = append(imageDataList, imageData)
 		}
 
-		// Check that all images have 'architecture' label with value 'x86_64'
+		// Check that all images have required labels with correct values
+		requiredLabels := support.RequiredImageLabels()
 		for _, imageData := range imageDataList {
-			Expect(imageData.Labels).To(HaveKey("architecture"),
-				fmt.Sprintf("Image %s is missing 'architecture' label", imageData.Image))
-			Expect(imageData.Labels["architecture"]).To(Equal("x86_64"),
-				fmt.Sprintf("Image %s has incorrect architecture label: expected 'x86_64', got '%s'",
-					imageData.Image, imageData.Labels["architecture"]))
-		}
+			for labelName, expectedValue := range requiredLabels {
+				Expect(imageData.Labels).To(HaveKey(labelName),
+					fmt.Sprintf("Image %s is missing '%s' label", imageData.Image, labelName))
 
-		// Check that all images have 'build-date' label which is not empty
-		for _, imageData := range imageDataList {
-			Expect(imageData.Labels).To(HaveKey("build-date"),
-				fmt.Sprintf("Image %s is missing 'build-date' label", imageData.Image))
-			Expect(imageData.Labels["build-date"]).NotTo(BeEmpty(),
-				fmt.Sprintf("Image %s has empty 'build-date' label", imageData.Image))
-		}
-
-		// Check that all images have 'short-commit' label which is not empty
-		for _, imageData := range imageDataList {
-			Expect(imageData.Labels).To(HaveKey("short-commit"),
-				fmt.Sprintf("Image %s is missing 'short-commit' label", imageData.Image))
-			Expect(imageData.Labels["short-commit"]).NotTo(BeEmpty(),
-				fmt.Sprintf("Image %s has empty 'short-commit' label", imageData.Image))
+				if expectedValue != "" {
+					// Specific value expected
+					Expect(imageData.Labels[labelName]).To(Equal(expectedValue),
+						fmt.Sprintf("Image %s has incorrect '%s' label: expected '%s', got '%s'",
+							imageData.Image, labelName, expectedValue, imageData.Labels[labelName]))
+				} else {
+					// Label must not be empty
+					Expect(imageData.Labels[labelName]).NotTo(BeEmpty(),
+						fmt.Sprintf("Image %s has empty '%s' label", imageData.Image, labelName))
+				}
+			}
 		}
 	})
 })

--- a/test/acceptance/releases_images_test.go
+++ b/test/acceptance/releases_images_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -53,7 +54,7 @@ var _ = Describe("Trusted Artifact Signer Releases", Ordered, func() {
 
 	It("snapshot.json images have correct labels", func() {
 		var imageDataList []support.ImageData
-		imageLablelsErrors := make(map[string][]string)
+		imageLabelsErrors := make(map[string][]string)
 
 		// Collect all images and their labels
 		for imageName, imageDefinition := range snapshotData.Images {
@@ -94,20 +95,22 @@ var _ = Describe("Trusted Artifact Signer Releases", Ordered, func() {
 			}
 
 			if len(currentImageErrors) > 0 {
-				imageLablelsErrors[imageData.Image] = currentImageErrors
+				imageLabelsErrors[imageData.Image] = currentImageErrors
 			}
 		}
 
 		// Format errors in a human-readable way
-		if len(imageLablelsErrors) > 0 {
-			var errorReport string
-			for image, errors := range imageLablelsErrors {
-				errorReport += image + ":\n"
+		if len(imageLabelsErrors) > 0 {
+			var errorReport strings.Builder
+			for image, errors := range imageLabelsErrors {
+				errorReport.WriteString(image)
+				errorReport.WriteString(":\n")
 				for _, error := range errors {
-					errorReport += error + "\n"
+					errorReport.WriteString(error)
+					errorReport.WriteString("\n")
 				}
 			}
-			Fail("Label validation errors found:\n" + errorReport)
+			Fail("Label validation errors found:\n" + errorReport.String())
 		}
 	})
 })

--- a/test/acceptance/releases_images_test.go
+++ b/test/acceptance/releases_images_test.go
@@ -102,9 +102,9 @@ var _ = Describe("Trusted Artifact Signer Releases", Ordered, func() {
 		if len(imageLablelsErrors) > 0 {
 			var errorReport string
 			for image, errors := range imageLablelsErrors {
-				errorReport += fmt.Sprintf("%s:\n", image)
+				errorReport += image + ":\n"
 				for _, error := range errors {
-					errorReport += fmt.Sprintf("%s\n", error)
+					errorReport += error + "\n"
 				}
 			}
 			Fail(fmt.Sprintf("Label validation errors found:\n%s", errorReport))

--- a/test/acceptance/releases_images_test.go
+++ b/test/acceptance/releases_images_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Trusted Artifact Signer Releases", Ordered, func() {
 					errorReport += error + "\n"
 				}
 			}
-			Fail(fmt.Sprintf("Label validation errors found:\n%s", errorReport))
+			Fail("Label validation errors found:\n" + errorReport)
 		}
 	})
 })

--- a/test/support/common.go
+++ b/test/support/common.go
@@ -94,5 +94,4 @@ func LogMapByProvidedKeys[V any](message string, data map[string]V, keysToLog []
 		result += fmt.Sprintf("    [%-53v] %v\n", key, data[key])
 	}
 	log.Print(result)
-
 }

--- a/test/support/common.go
+++ b/test/support/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 )
 
 func GetEnv(key string) string {
@@ -26,7 +27,7 @@ func getEnv(key string, isSecret bool) string {
 	return envValue
 }
 
-func GetMapKeys(m map[string]string) []string {
+func GetMapKeys[V any](m map[string]V) []string {
 	result := make([]string, 0, len(m))
 	for k := range m {
 		result = append(result, k)
@@ -40,6 +41,12 @@ func GetMapValues(m map[string]string) []string {
 		result = append(result, v)
 	}
 	return result
+}
+
+func GetMapKeysSorted[V any](m map[string]V) []string {
+	keys := GetMapKeys(m)
+	slices.Sort(keys)
+	return keys
 }
 
 func SplitMap(original map[string]string, keysToKeep []string) (map[string]string, map[string]string) {
@@ -73,10 +80,19 @@ func LogArray(message string, data []string) {
 	log.Print(result)
 }
 
-func LogMap(message string, data map[string]string) {
+func LogMap[V any](message string, data map[string]V) {
 	result := message + "\n"
 	for key, value := range data {
-		result += fmt.Sprintf("    [%-41s] %s\n", key, value)
+		result += fmt.Sprintf("    [%-41v] %v\n", key, value)
 	}
 	log.Print(result)
+}
+
+func LogMapByProvidedKeys[V any](message string, data map[string]V, keysToLog []string) {
+	result := message + "\n"
+	for _, key := range keysToLog {
+		result += fmt.Sprintf("    [%-53v] %v\n", key, data[key])
+	}
+	log.Print(result)
+
 }

--- a/test/support/image_utils.go
+++ b/test/support/image_utils.go
@@ -44,7 +44,9 @@ func PullImageIfNotPresentLocally(ctx context.Context, imageDefinition string) e
 		}
 		defer pullResp.Close()
 		// ensure the pull operation completes.
-		io.Copy(io.Discard, pullResp)
+		if _, err := io.Copy(io.Discard, pullResp); err != nil {
+			return fmt.Errorf("failed to read pull response: %w", err)
+		}
 		return nil
 	}
 

--- a/test/support/image_utils.go
+++ b/test/support/image_utils.go
@@ -16,21 +16,54 @@ import (
 	"github.com/docker/docker/client"
 )
 
+type ImageData struct {
+	Image  string
+	Labels map[string]string
+}
+
+func PullImageIfNotPresentLocally(ctx context.Context, imageDefinition string) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("could not create docker client: %w", err)
+	}
+	defer cli.Close()
+
+	// Inspect the image to check if it exists locally.
+	_, _, err = cli.ImageInspectWithRaw(ctx, imageDefinition)
+	if err == nil {
+		return nil // image is present already
+	}
+
+	if client.IsErrNotFound(err) {
+		log.Printf("Image '%s' not found locally, pulling...\n", imageDefinition)
+		pullResp, pullErr := cli.ImagePull(ctx, imageDefinition, image.PullOptions{
+			Platform: "linux/amd64",
+		})
+		if pullErr != nil {
+			return fmt.Errorf("failed to pull image: %w", pullErr)
+		}
+		defer pullResp.Close()
+		// ensure the pull operation completes.
+		io.Copy(io.Discard, pullResp)
+		return nil
+	}
+
+	// another type of error, return it.
+	return fmt.Errorf("failed to inspect image: %w", err)
+}
+
 func RunImage(imageDefinition string, commands []string) (string, error) {
 	ctx := context.TODO()
+	err := PullImageIfNotPresentLocally(ctx, imageDefinition)
+	if err != nil {
+		return "", err
+	}
+
 	log.Printf("Running image %s with commands %v\n", imageDefinition, commands)
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return "", fmt.Errorf("error while initializing docker client: %w", err)
 	}
-	reader, err := cli.ImagePull(ctx, imageDefinition, image.PullOptions{
-		Platform: "linux/amd64",
-	})
-	if err != nil {
-		return "", fmt.Errorf("cannot pull image %s: %w", imageDefinition, err)
-	}
-	_, _ = io.Copy(os.Stdout, reader)
-	_ = reader.Close()
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: imageDefinition,
@@ -69,21 +102,53 @@ func RunImage(imageDefinition string, commands []string) (string, error) {
 	return buf.String(), nil
 }
 
+func InspectImageForLabels(imageDefinition string) (map[string]string, error) {
+	ctx := context.TODO()
+	err := PullImageIfNotPresentLocally(ctx, imageDefinition)
+	if err != nil {
+		return nil, err
+	}
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, fmt.Errorf("error while initializing docker client: %w", err)
+	}
+	defer cli.Close()
+
+	inspectData, _, err := cli.ImageInspectWithRaw(ctx, imageDefinition)
+	if err != nil {
+		return nil, fmt.Errorf("cannot inspect image %s: %w", imageDefinition, err)
+	}
+	if inspectData.Config == nil || len(inspectData.Config.Labels) == 0 {
+		log.Printf("Image [%s] does not have any labels\n", imageDefinition)
+		return make(map[string]string), nil
+	}
+
+	return inspectData.Config.Labels, nil
+}
+
+func GetImageLabel(imageDefinition, labelName string) (string, error) {
+	labels, err := InspectImageForLabels(imageDefinition)
+	if err != nil {
+		return "", err
+	}
+	if labelValue, ok := labels[labelName]; ok {
+		return labelValue, nil
+	}
+	return "", fmt.Errorf("label [%s] not found in image %s", labelName, imageDefinition)
+}
+
 func FileFromImage(ctx context.Context, imageName, filePath, outputPath string) error {
+	err := PullImageIfNotPresentLocally(ctx, imageName)
+	if err != nil {
+		return err
+	}
+
 	// Initialize the Docker client
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		panic(err)
 	}
-
-	reader, err := cli.ImagePull(ctx, imageName, image.PullOptions{
-		Platform: "linux/amd64",
-	})
-	if err != nil {
-		return fmt.Errorf("cannot pull image %s: %w", imageName, err)
-	}
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
 
 	// Create a container from the image
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
@@ -102,7 +167,7 @@ func FileFromImage(ctx context.Context, imageName, filePath, outputPath string) 
 	}()
 
 	// Use Docker's API to copy the file from the container's filesystem
-	reader, _, err = cli.CopyFromContainer(ctx, resp.ID, filePath)
+	reader, _, err := cli.CopyFromContainer(ctx, resp.ID, filePath)
 	if err != nil {
 		return fmt.Errorf("failed to copy file from container: %w", err)
 	}

--- a/test/support/test_constants.go
+++ b/test/support/test_constants.go
@@ -94,17 +94,13 @@ func GetOSArchMatrix() OSArchMatrix {
 	}
 }
 
-// RequiredImageLabels returns a map of required image labels.
-// If the value is not empty, it's the expected value for the label.
-// If the value is empty, the label must exist but can have any non-empty value.
+// If no value is provided, the label must exist, but can have any non-empty value.
 func RequiredImageLabels() map[string]string {
 	return map[string]string{
 		"architecture": "x86_64",
 		"build-date":   "",
-		"short-commit": "",
 		"vcs-ref":      "",
 		"vcs-type":     "git",
 		"vendor":       "Red Hat, Inc.",
-		"version":      "1.3.0",
 	}
 }

--- a/test/support/test_constants.go
+++ b/test/support/test_constants.go
@@ -93,3 +93,18 @@ func GetOSArchMatrix() OSArchMatrix {
 		"windows": {"amd64"},
 	}
 }
+
+// RequiredImageLabels returns a map of required image labels.
+// If the value is not empty, it's the expected value for the label.
+// If the value is empty, the label must exist but can have any non-empty value.
+func RequiredImageLabels() map[string]string {
+	return map[string]string{
+		"architecture": "x86_64",
+		"build-date":   "",
+		"short-commit": "",
+		"vcs-ref":      "",
+		"vcs-type":     "git",
+		"vendor":       "Red Hat, Inc.",
+		"version":      "1.3.0",
+	}
+}


### PR DESCRIPTION
Check labels of all images
- check, if all we care of are filled,
- if they have all the same expected values,
- operator and operator-bundle images have the same git reference.

Currently we check only few basic labels, other will be decided later.

Other improvement is, that images are pulled only once for all the tests. This improves performance significantly.

## Summary by Sourcery

Add utilities and tests for inspecting and validating Docker image labels, refactor existing image handling to reuse a shared pull function, and extend test support with generic map operations

New Features:
- Provide PullImageIfNotPresentLocally to fetch Docker images only if missing
- Add InspectImageForLabels and GetImageLabel to extract labels from Docker images
- Introduce generic map utilities (GetMapKeysSorted, generic LogMap, LogMapByProvidedKeys) for test support

Enhancements:
- Refactor RunImage and FileFromImage to reuse the new pull logic and remove duplicate code
- Define ImageData struct to pair image names with their labels for easier test assertions

Tests:
- Implement tests to confirm matching vcs-ref labels for operator and operator-bundle images
- Implement tests that inspect and report label counts for all snapshot.json images

## Summary by Sourcery

Add reusable utilities for pulling Docker images and inspecting their labels, refactor existing image handling to use the new pull logic, and extend acceptance tests to validate image labels using generic map helpers

New Features:
- Add PullImageIfNotPresentLocally to fetch Docker images only when missing
- Add InspectImageForLabels and GetImageLabel functions to extract labels from images
- Introduce ImageData struct for pairing image definitions with their labels
- Add RequiredImageLabels function to define expected image labels
- Introduce generic map utilities (GetMapKeysSorted, LogMap, LogMapByProvidedKeys) for test support

Enhancements:
- Refactor RunImage and FileFromImage to reuse shared pull logic and reduce duplicate code
- Optimize tests to pull each image only once for improved performance

Tests:
- Add test to verify operator and operator-bundle images share the same vcs-ref label
- Add test to validate presence and correctness of required labels for all snapshot.json images