### PR TITLE
1.4.2/clichain verification

### DIFF
--- a/test/acceptance/rhtas/client_server_test.go
+++ b/test/acceptance/rhtas/client_server_test.go
@@ -314,6 +314,9 @@ var _ = Describe("Client server", Ordered, func() {
 							clientBinarySHA, err := checksumFile(clientBinaryPath)
 							Expect(err).NotTo(HaveOccurred())
 
+							// Clean up client-server binary immediately after checksum
+							_ = os.Remove(clientBinaryPath)
+
 							// Step 2: Get binary from cli-stack (.tar.gz format)
 							stackKey := snapshotKeyForCLIStack(cli)
 							stackImage := snapshotData.Images[stackKey]
@@ -343,6 +346,10 @@ var _ = Describe("Client server", Ordered, func() {
 
 							stackBinarySHA, err := checksumFile(stackBinaryPath)
 							Expect(err).NotTo(HaveOccurred())
+
+							// Clean up cli-stack files immediately after checksum
+							_ = os.Remove(stackBinaryPath)
+							_ = os.Remove(tarGzPath)
 
 							By("compare client-server binary with cli-stack binary")
 							Expect(clientBinarySHA).To(Equal(stackBinarySHA),
@@ -414,6 +421,9 @@ var _ = Describe("Client server", Ordered, func() {
 								tasToolsBinarySHA, err := checksumFile(tasToolsBinaryPath)
 								Expect(err).NotTo(HaveOccurred())
 
+								// Clean up tas-tools binary immediately after checksum
+								_ = os.Remove(tasToolsBinaryPath)
+
 								By("compare cli-stack binary with tas-tools binary")
 								Expect(stackBinarySHA).To(Equal(tasToolsBinarySHA),
 									"cli-stack binary should match tas-tools binary")
@@ -436,8 +446,12 @@ var _ = Describe("Client server", Ordered, func() {
 
 							By("checksums of gzip file")
 							fileName := filepath.Base(srcPath)
-							gzipImageSHA, err := checksumFile(filepath.Join(targetPath, fileName))
+							filePath := filepath.Join(targetPath, fileName)
+							gzipImageSHA, err := checksumFile(filePath)
 							Expect(err).NotTo(HaveOccurred())
+
+							// Clean up extracted file immediately after checksum
+							_ = os.Remove(filePath)
 
 							By("compare checksum with client server file")
 							Expect(gzipImageSHA).To(Equal(gzipServerSHA))
@@ -484,8 +498,12 @@ var _ = Describe("Client server", Ordered, func() {
 							Expect(support.FileFromImage(ctx, image, filePath, targetPath)).To(Succeed())
 
 							By("checksums of gzip file")
-							gzipImageSHA, err := checksumFile(filepath.Join(targetPath, fileName))
+							extractedFile := filepath.Join(targetPath, fileName)
+							gzipImageSHA, err := checksumFile(extractedFile)
 							Expect(err).NotTo(HaveOccurred())
+
+							// Clean up extracted file immediately after checksum
+							_ = os.Remove(extractedFile)
 
 							By("compare checksum with client server file")
 							Expect(gzipImageSHA).To(Equal(gzipServerSHA))

--- a/test/acceptance/rhtas/client_server_test.go
+++ b/test/acceptance/rhtas/client_server_test.go
@@ -23,10 +23,10 @@ const (
 	cliServerFileMask = "%s-%s.gz"
 	cliServerPathMask = "/var/www/html/clients/%s/" + cliServerFileMask
 
-	cliImageBasePath        = "/usr/local/bin"
-	cliImageFileMask        = "%s_cli_%s_%s.gz"
-	cliStackImageBasePath   = "/binaries"
-	cliStackImageFileMask   = "%s_%s_%s.tar.gz"
+	cliImageBasePath      = "/usr/local/bin"
+	cliImageFileMask      = "%s_cli_%s_%s.gz"
+	cliStackImageBasePath = "/binaries"
+	cliStackImageFileMask = "%s_%s_%s.tar.gz"
 
 	osLinux   = "linux"
 	osDarwin  = "darwin"
@@ -65,7 +65,7 @@ func snapshotKeyForCLI(cli string) string {
 	}
 }
 
-// snapshotKeyForCLIStack returns the snapshot key for cli-stack images (1.4.2+)
+// snapshotKeyForCLIStack returns the snapshot key for cli-stack images (1.4.2+).
 func snapshotKeyForCLIStack(cli string) string {
 	switch cli {
 	case cliCreatetree, cliUpdatetree:

--- a/test/acceptance/rhtas/client_server_test.go
+++ b/test/acceptance/rhtas/client_server_test.go
@@ -23,8 +23,10 @@ const (
 	cliServerFileMask = "%s-%s.gz"
 	cliServerPathMask = "/var/www/html/clients/%s/" + cliServerFileMask
 
-	cliImageBasePath = "/usr/local/bin"
-	cliImageFileMask = "%s_cli_%s_%s.gz"
+	cliImageBasePath        = "/usr/local/bin"
+	cliImageFileMask        = "%s_cli_%s_%s.gz"
+	cliStackImageBasePath   = "/binaries"
+	cliStackImageFileMask   = "%s_%s_%s.tar.gz"
 
 	osLinux   = "linux"
 	osDarwin  = "darwin"
@@ -63,6 +65,26 @@ func snapshotKeyForCLI(cli string) string {
 	}
 }
 
+// snapshotKeyForCLIStack returns the snapshot key for cli-stack images (1.4.2+)
+func snapshotKeyForCLIStack(cli string) string {
+	switch cli {
+	case cliCreatetree, cliUpdatetree:
+		return "trillian-cli-stack-image"
+	case cliTuftool:
+		return "tuftool-cli-stack-image"
+	case cliRekorCli:
+		return "rekor-cli-stack-image"
+	case cliFetchTsaCerts:
+		return "fetch-tsa-certs-cli-stack-image"
+	case cliCosign:
+		return "cosign-cli-stack-image"
+	case cliGitsign:
+		return "gitsign-cli-stack-image"
+	default:
+		return ""
+	}
+}
+
 func isMultiArchImageKey(key string) bool {
 	for _, k := range multiArchCLISnapshotKeys {
 		if k == key {
@@ -70,6 +92,31 @@ func isMultiArchImageKey(key string) bool {
 		}
 	}
 	return false
+}
+
+// sourcePathInStackImage returns the path inside CLI stack images (1.4.0+).
+// CLI stack images use /binaries/ base path and .tar.gz format.
+func sourcePathInStackImage(cli, osName, arch string) string {
+	var binaryName string
+	switch cli {
+	case cliCosign:
+		binaryName = "cosign"
+	case cliGitsign:
+		binaryName = "gitsign_cli"
+	case cliRekorCli:
+		binaryName = "rekor_cli"
+	case cliFetchTsaCerts:
+		binaryName = "fetch_tsa_certs"
+	case cliCreatetree:
+		binaryName = "createtree"
+	case cliUpdatetree:
+		binaryName = "updatetree"
+	case cliTuftool:
+		binaryName = "tuftool"
+	default:
+		return ""
+	}
+	return fmt.Sprintf("%s/%s_%s_%s.tar.gz", cliStackImageBasePath, binaryName, osName, arch)
 }
 
 func sourcePathCosign(osName, arch string) string {
@@ -144,8 +191,9 @@ func sourcePathUpdatetree(osName, arch string) string {
 	return ""
 }
 
-// sourcePathInImageMultiArch returns the path inside the CLI source image for the given (os, arch).
+// sourcePathInImageMultiArch returns the path inside the tas-tools CLI source image for the given (os, arch).
 // Only for multiarch CLIs (cosign, gitsign, rekor-cli, fetch-tsa-certs, createtree, updatetree).
+// tas-tools images use /usr/local/bin/ base path and .gz format for all versions.
 func sourcePathInImageMultiArch(cli, osName, arch string) string {
 	base := cliImageBasePath + "/"
 	var suffix string
@@ -252,7 +300,114 @@ var _ = Describe("Client server", Ordered, func() {
 						serverChecksums[cli+"/"+osName+"/"+arch] = append([]byte(nil), gzipServerSHA...)
 					})
 
-					if support.IsVersionAtLeast("1.4.0") && isMultiArchImageKey(snapshotKeyForCLI(cli)) {
+					if support.IsVersionAtLeast("1.4.2") && snapshotKeyForCLIStack(cli) != "" {
+						// For 1.4.2+: verify the full chain: tas-tools → cli-stack → client-server
+						It(fmt.Sprintf("verify %s-%s binary matches cli-stack and tas-tools", osName, arch), func() {
+							// Step 1: Get binary from client-server (.gz format)
+							clientServerDir := filepath.Join(tmpDir, "verify-chain", "client-server", cli, osName, arch)
+							Expect(os.MkdirAll(clientServerDir, 0755)).To(Succeed())
+
+							gzPath := filepath.Join(tmpDir, osName, fmt.Sprintf(cliServerFileMask, cli, arch))
+							clientBinaryPath := filepath.Join(clientServerDir, "binary-from-client-server")
+							Expect(support.DecompressGzipFile(gzPath, clientBinaryPath)).To(Succeed())
+
+							clientBinarySHA, err := checksumFile(clientBinaryPath)
+							Expect(err).NotTo(HaveOccurred())
+
+							// Step 2: Get binary from cli-stack (.tar.gz format)
+							stackKey := snapshotKeyForCLIStack(cli)
+							stackImage := snapshotData.Images[stackKey]
+							Expect(stackImage).NotTo(BeEmpty(), "cli-stack image not found: %s", stackKey)
+
+							srcPath := sourcePathInStackImage(cli, osName, arch)
+							Expect(srcPath).NotTo(BeEmpty(), "no source path for %s %s/%s", cli, osName, arch)
+
+							ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+							defer cancel()
+
+							By(fmt.Sprintf("resolve linux/%s variant of cli-stack image", arch))
+							platformImage, err := support.ResolveManifestListForPlatform(ctx, stackImage, "linux/"+arch)
+							if err != nil {
+								platformImage = stackImage
+							}
+
+							By("get tar.gz file from cli-stack image")
+							stackDir := filepath.Join(tmpDir, "verify-chain", "cli-stack", cli, osName, arch)
+							Expect(os.MkdirAll(stackDir, 0755)).To(Succeed())
+							Expect(support.FileFromImage(ctx, platformImage, srcPath, stackDir)).To(Succeed())
+
+							By("extract binary from tar.gz")
+							tarGzPath := filepath.Join(stackDir, filepath.Base(srcPath))
+							stackBinaryPath, err := support.ExtractFirstFileFromTarGz(tarGzPath, stackDir)
+							Expect(err).NotTo(HaveOccurred())
+
+							stackBinarySHA, err := checksumFile(stackBinaryPath)
+							Expect(err).NotTo(HaveOccurred())
+
+							By("compare client-server binary with cli-stack binary")
+							Expect(clientBinarySHA).To(Equal(stackBinarySHA),
+								"client-server binary should match cli-stack binary")
+
+							// Step 3: Verify cli-stack → tas-tools chain (Linux targets only)
+							// Note: cli-stack gets Linux binaries from tas-tools, but darwin/windows from cross-compilation
+							if osName == osLinux && isMultiArchImageKey(snapshotKeyForCLI(cli)) {
+								By("verify cli-stack binary matches tas-tools source")
+								tasToolsImage := snapshotData.Images[snapshotKeyForCLI(cli)]
+								Expect(tasToolsImage).NotTo(BeEmpty())
+
+								By(fmt.Sprintf("resolve linux/%s variant of tas-tools image", arch))
+								tasPlatformImage, err := support.ResolveManifestListForPlatform(ctx, tasToolsImage, "linux/"+arch)
+								Expect(err).NotTo(HaveOccurred())
+
+								tasToolsDir := filepath.Join(tmpDir, "verify-chain", "tas-tools", cli, osName, arch)
+								Expect(os.MkdirAll(tasToolsDir, 0755)).To(Succeed())
+
+								// tas-tools has binary at /usr/local/bin/{binary} (not tarred)
+								// Binary names in tas-tools images differ from CLI names
+								var binaryName string
+								switch cli {
+								case cliGitsign:
+									binaryName = "gitsign_cli_linux"
+								case cliRekorCli:
+									binaryName = "rekor_cli_linux"
+								case cliFetchTsaCerts:
+									binaryName = "fetch_tsa_certs"
+								case cliCreatetree:
+									binaryName = "createtree"
+								case cliUpdatetree:
+									binaryName = "updatetree"
+								default:
+									binaryName = cli
+								}
+
+								// Binary path in tas-tools images
+								var tasToolsImagePath string
+								if cli == cliCreatetree || cli == cliUpdatetree {
+									// createtree and updatetree are at root directory
+									tasToolsImagePath = "/" + binaryName
+								} else {
+									// Others are in /usr/local/bin/
+									tasToolsImagePath = "/usr/local/bin/" + binaryName
+								}
+
+								tasToolsBinaryPath := filepath.Join(tasToolsDir, "binary-from-tas-tools")
+								Expect(support.FileFromImage(ctx, tasPlatformImage, tasToolsImagePath, tasToolsDir)).To(Succeed())
+
+								// The file is downloaded with the basename, rename it
+								downloadedPath := filepath.Join(tasToolsDir, filepath.Base(tasToolsImagePath))
+								if downloadedPath != tasToolsBinaryPath {
+									Expect(os.Rename(downloadedPath, tasToolsBinaryPath)).To(Succeed())
+								}
+
+								tasToolsBinarySHA, err := checksumFile(tasToolsBinaryPath)
+								Expect(err).NotTo(HaveOccurred())
+
+								By("compare cli-stack binary with tas-tools binary")
+								Expect(stackBinarySHA).To(Equal(tasToolsBinarySHA),
+									"cli-stack binary should match tas-tools binary")
+							}
+						})
+					} else if support.IsVersionAtLeast("1.4.0") && isMultiArchImageKey(snapshotKeyForCLI(cli)) {
 						It(fmt.Sprintf("compare checksum of %s-%s with multiarch source image", osName, arch), func() {
 							srcPath := sourcePathInImageMultiArch(cli, osName, arch)
 							Expect(srcPath).NotTo(BeEmpty(), "no source path for %s %s/%s", cli, osName, arch)
@@ -342,6 +497,9 @@ var _ = Describe("Client server", Ordered, func() {
 	It("compare all multiarch binaries (all CLIs) with source images", func() {
 		if support.IsBeforeVersion("1.4.0") {
 			Skip("multiarch comparison only for version 1.4.0 and later")
+		}
+		if support.IsVersionAtLeast("1.4.2") {
+			Skip("multiarch comparison skipped for 1.4.2+, client-server uses cli-stack images")
 		}
 		matrix := support.GetOSArchMatrix()
 		var errMsgs []string

--- a/test/acceptance/rhtas/client_server_test.go
+++ b/test/acceptance/rhtas/client_server_test.go
@@ -350,14 +350,21 @@ var _ = Describe("Client server", Ordered, func() {
 
 							// Step 3: Verify cli-stack → tas-tools chain (Linux targets only)
 							// Note: cli-stack gets Linux binaries from tas-tools, but darwin/windows from cross-compilation
-							if osName == osLinux && isMultiArchImageKey(snapshotKeyForCLI(cli)) {
+							// tuftool is a special case: it's only built for linux/amd64 and comes from tuf-tool-image
+							if osName == osLinux && (isMultiArchImageKey(snapshotKeyForCLI(cli)) || cli == cliTuftool) {
 								By("verify cli-stack binary matches tas-tools source")
 								tasToolsImage := snapshotData.Images[snapshotKeyForCLI(cli)]
 								Expect(tasToolsImage).NotTo(BeEmpty())
 
 								By(fmt.Sprintf("resolve linux/%s variant of tas-tools image", arch))
-								tasPlatformImage, err := support.ResolveManifestListForPlatform(ctx, tasToolsImage, "linux/"+arch)
-								Expect(err).NotTo(HaveOccurred())
+								var tasPlatformImage string
+								if cli == cliTuftool {
+									// tuftool's tuf-tool-image is a single-arch image, not a manifest list
+									tasPlatformImage = tasToolsImage
+								} else {
+									tasPlatformImage, err = support.ResolveManifestListForPlatform(ctx, tasToolsImage, "linux/"+arch)
+									Expect(err).NotTo(HaveOccurred())
+								}
 
 								tasToolsDir := filepath.Join(tmpDir, "verify-chain", "tas-tools", cli, osName, arch)
 								Expect(os.MkdirAll(tasToolsDir, 0755)).To(Succeed())
@@ -376,6 +383,8 @@ var _ = Describe("Client server", Ordered, func() {
 									binaryName = "createtree"
 								case cliUpdatetree:
 									binaryName = "updatetree"
+								case cliTuftool:
+									binaryName = "tuftool"
 								default:
 									binaryName = cli
 								}
@@ -385,6 +394,9 @@ var _ = Describe("Client server", Ordered, func() {
 								if cli == cliCreatetree || cli == cliUpdatetree {
 									// createtree and updatetree are at root directory
 									tasToolsImagePath = "/" + binaryName
+								} else if cli == cliTuftool {
+									// tuftool is in /usr/bin/
+									tasToolsImagePath = "/usr/bin/" + binaryName
 								} else {
 									// Others are in /usr/local/bin/
 									tasToolsImagePath = "/usr/local/bin/" + binaryName

--- a/test/acceptance/rhtas/releases_images_test.go
+++ b/test/acceptance/rhtas/releases_images_test.go
@@ -53,20 +53,11 @@ var _ = Describe("Trusted Artifact Signer Releases", Ordered, func() {
 	})
 
 	It("snapshot.json images have correct labels", func() {
-		var imageDataList []support.ImageData
 		imageLabelsErrors := make(map[string][]string)
 
-		// Collect all images and their labels
-		for imageName, imageDefinition := range snapshotData.Images {
-			labels, err := support.InspectImageForLabels(imageDefinition)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to inspect labels for image %s (%s)", imageName, imageDefinition))
-
-			imageData := support.ImageData{
-				Image:  imageDefinition,
-				Labels: labels,
-			}
-			imageDataList = append(imageDataList, imageData)
-		}
+		// Collect all images and their labels in parallel (10 concurrent pulls)
+		imageDataList, err := support.InspectImagesForLabelsParallel(snapshotData.Images, 10)
+		Expect(err).NotTo(HaveOccurred(), "Failed to inspect images for labels")
 
 		// Check that all images have required labels with correct values
 		requiredLabels := support.RequiredImageLabels()

--- a/test/support/image_utils.go
+++ b/test/support/image_utils.go
@@ -167,7 +167,7 @@ func InspectImagesForLabelsParallel(images map[string]string, maxConcurrency int
 	// Launch goroutines for each image
 	for imageName, imageDefinition := range images {
 		go func(name, definition string) {
-			semaphore <- struct{}{} // acquire
+			semaphore <- struct{}{}        // acquire
 			defer func() { <-semaphore }() // release
 
 			labels, err := InspectImageForLabels(definition)
@@ -186,7 +186,7 @@ func InspectImagesForLabelsParallel(images map[string]string, maxConcurrency int
 	imageDataList := make([]ImageData, 0, len(images))
 	var errs []error
 
-	for i := 0; i < len(images); i++ {
+	for range len(images) {
 		res := <-results
 		if res.err != nil {
 			errs = append(errs, fmt.Errorf("image %s (%s): %w", res.imageName, res.data.Image, res.err))

--- a/test/support/image_utils.go
+++ b/test/support/image_utils.go
@@ -148,6 +148,64 @@ func GetImageLabel(imageDefinition, labelName string) (string, error) {
 	return "", fmt.Errorf("label [%s] not found in image %s", labelName, imageDefinition)
 }
 
+// InspectImagesForLabelsParallel inspects multiple images concurrently and returns their labels.
+// maxConcurrency controls how many images are inspected at once (0 = unlimited).
+func InspectImagesForLabelsParallel(images map[string]string, maxConcurrency int) ([]ImageData, error) {
+	if maxConcurrency <= 0 {
+		maxConcurrency = 10 // default to 10 concurrent pulls
+	}
+
+	type result struct {
+		imageName string
+		data      ImageData
+		err       error
+	}
+
+	results := make(chan result, len(images))
+	semaphore := make(chan struct{}, maxConcurrency)
+
+	// Launch goroutines for each image
+	for imageName, imageDefinition := range images {
+		go func(name, definition string) {
+			semaphore <- struct{}{} // acquire
+			defer func() { <-semaphore }() // release
+
+			labels, err := InspectImageForLabels(definition)
+			results <- result{
+				imageName: name,
+				data: ImageData{
+					Image:  definition,
+					Labels: labels,
+				},
+				err: err,
+			}
+		}(imageName, imageDefinition)
+	}
+
+	// Collect results
+	imageDataList := make([]ImageData, 0, len(images))
+	var errs []error
+
+	for i := 0; i < len(images); i++ {
+		res := <-results
+		if res.err != nil {
+			errs = append(errs, fmt.Errorf("image %s (%s): %w", res.imageName, res.data.Image, res.err))
+		} else {
+			imageDataList = append(imageDataList, res.data)
+		}
+	}
+
+	if len(errs) > 0 {
+		// Return first error, but log all
+		for _, err := range errs {
+			log.Printf("Image inspection error: %v", err)
+		}
+		return imageDataList, errs[0]
+	}
+
+	return imageDataList, nil
+}
+
 func FileFromImage(ctx context.Context, imageName, filePath, outputPath string) error {
 	err := PullImageIfNotPresentLocally(ctx, imageName)
 	if err != nil {


### PR DESCRIPTION
Inclusion of cli-stacks in comparison with tas-tools and client-server was causing timeouts. Added checks to ensure checksums match across all 3