### PR TITLE
add: sigstore-a2a acceptance structural tests

### DIFF
--- a/test/acceptance/sigstore_a2a/releases_images_test.go
+++ b/test/acceptance/sigstore_a2a/releases_images_test.go
@@ -1,0 +1,43 @@
+package acceptance
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/securesign/structural-tests/test/support"
+)
+
+var _ = Describe("Sigstore A2A Releases", Ordered, func() {
+
+	var (
+		snapshotData support.SnapshotData
+	)
+
+	It("snapshot.json file exist and is parseable", func() {
+		var err error
+		snapshotData, err = support.ParseSnapshotData()
+		Expect(err).NotTo(HaveOccurred())
+		support.LogMap(fmt.Sprintf("Snapshot images (%d):", len(snapshotData.Images)), snapshotData.Images)
+		Expect(snapshotData.Images).NotTo(BeEmpty(), "No images were detected in snapshot file")
+	})
+
+	It("snapshot.json file contains valid images", func() {
+		Expect(snapshotData.Images).To(HaveEach(MatchRegexp(support.SnapshotImageDefinitionRegexp)))
+	})
+
+	It("snapshot.json file image snapshots are all unique", func() {
+		snapshotHashes := support.ExtractHashes(support.GetMapValues(snapshotData.Images))
+		mapped := make(map[string]int)
+		for _, hash := range snapshotHashes {
+			_, exist := mapped[hash]
+			if exist {
+				mapped[hash]++
+			} else {
+				mapped[hash] = 1
+			}
+		}
+		Expect(mapped).To(HaveEach(1))
+		Expect(len(snapshotData.Images)).To(BeNumerically("==", len(mapped)))
+	})
+})

--- a/test/acceptance/sigstore_a2a/sigstore_a2a_acceptance_suite_test.go
+++ b/test/acceptance/sigstore_a2a/sigstore_a2a_acceptance_suite_test.go
@@ -1,0 +1,18 @@
+package acceptance
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestAcceptance(t *testing.T) {
+	format.MaxLength = 0
+
+	RegisterFailHandler(Fail)
+	log.SetLogger(GinkgoLogr)
+	RunSpecs(t, "Sigstore A2A Acceptance Tests Suite")
+}


### PR DESCRIPTION
## Summary
- Add acceptance structural tests for the sigstore-a2a component
- Follows the same Tier 3 pattern (releases-only, no operator/FBC)
- Validates snapshot.json parsing, image format, and hash uniqueness

## Test plan
- [ ] Verify `go vet ./test/acceptance/sigstore_a2a/...` passes
- [ ] Verify tests run successfully with a valid sigstore-a2a snapshot.json via `SNAPSHOT` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)